### PR TITLE
create all nodes in network first using all values from the agents dict

### DIFF
--- a/mann/network_agent.py
+++ b/mann/network_agent.py
@@ -27,6 +27,9 @@ class NetworkAgent(object):
 
         print('total number of agents created: ', new_agent.agent_count)
 
+        self.G.add_nodes_from(all_agents.values())
+        print('number of nodes created: ', len(self.G))
+
         for edge in edge_list:
             u, v = edge
             self.G.add_edge(all_agents[u], all_agents[v])


### PR DESCRIPTION
fixes #16 

the agents are all created and added to an agents dictionary where the key is the agent key.

the network then creates all the nodes (without any edges) by populating it with all the VALUES of the dictionary, in this case all the agents.

This fixes the issue of singletons being dropped from the network of agents when edges are created.
